### PR TITLE
BUG: Computed object property and class member cases are not properly handled

### DIFF
--- a/test/__snapshots__/main.test.js.snap
+++ b/test/__snapshots__/main.test.js.snap
@@ -27,3 +27,11 @@ exports[`main unused VariableDeclarator 1`] = `
   const Tab = '123';
 })();"
 `;
+
+exports[`main used ObjectProperty 1`] = `
+"var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+import Tab from 'tab';
+
+export const x = _extends({ [Tab]: 'abc' }, { a: '2' });"
+`;

--- a/test/fixture/used/ObjectProperty.js
+++ b/test/fixture/used/ObjectProperty.js
@@ -1,0 +1,3 @@
+import Tab from 'tab'
+
+export const x = { [Tab]: 'abc', ...{ a: '2' } }

--- a/test/fixture/used/class-2.js
+++ b/test/fixture/used/class-2.js
@@ -1,0 +1,5 @@
+import Tab from 'tab'
+
+export class A {
+  static [Tab]() {}
+}

--- a/test/fixture/used/class.js
+++ b/test/fixture/used/class.js
@@ -1,0 +1,5 @@
+import Tab from 'tab'
+
+export class A {
+  [Tab]() {}
+}

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -98,6 +98,43 @@ class A {
 const comp = React.createElement(Tab, null);"
 `)
     })
+
+    it('ObjectProperty', function() {
+      expect(
+        transformTest(
+          'used/ObjectProperty.js',
+          {},
+          { presets: ['babel-preset-stage-0'] }
+        ).code
+      ).toMatchSnapshot()
+    })
+
+    it('class', function() {
+      expect(
+        transformTest(
+          'used/class.js',
+          {},
+          { presets: ['babel-preset-stage-0'] }
+        ).code
+      ).toMatchInlineSnapshot(`
+"import Tab from 'tab';
+
+export class A {
+  [Tab]() {}
+}"
+`)
+    })
+
+    it('class-2', function() {
+      expect(transformTest('used/class-2.js', {}, { presets: ['react'] }).code)
+        .toMatchInlineSnapshot(`
+"import Tab from 'tab';
+
+export class A {
+  static [Tab]() {}
+}"
+`)
+    })
   })
 
   describe('options', () => {


### PR DESCRIPTION
### Problem

Cases related to computed object properties or class members are not properly handled.

Input:
```
import Tab from 'tab'

export class A {
  [Tab]() {}
}
```

Expected output:
```
import Tab from 'tab';

export class A {
  [Tab]() {}
}
```

Actual output:
```
export class A {
  [Tab]() {}
}
```

I have submitted related test cases in this pr.

### Cause

`babel-plugin-danger-remove-unused-import` contains an implementation of scope and reference count, but it doesn't handle computed members well.

### Suggested solution

Babel ast comes with scope analysis result. `path.scope.bindings` should be investigated instead.

Docs:
https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#toc-bindings
